### PR TITLE
Add process.browser to bundle

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ function build() {
       plugins: [
         new webpack.optimize.UglifyJsPlugin({mangle: false, sourcemap: false}),
         new webpack.DefinePlugin({
-          'process.env.NODE_ENV': 'production'
+          'process.env.NODE_ENV': 'production',
+          'process.browser': true
         })
       ]
     }, (err, stats) => {


### PR DESCRIPTION
Some packages use stuff like

```js
if (!process.browser) { ... }
```

This change will remove any non browser code from those modules.