### PR TITLE
Fix production env replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function build (file) {
       entry: requireRelative.resolve(file, tmp),
       plugins: [
         new webpack.optimize.UglifyJsPlugin({ mangle: false, sourcemap: false }),
-        new webpack.DefinePlugin({ 'process.env.NODE_ENV': 'production', 'process.browser': true })
+        new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"production"', 'process.browser': true })
       ]
     }, (err, stats) => {
       if (err || stats.hasErrors()) reject(err || new Error(stats.toString('errors-only')))


### PR DESCRIPTION
The tool was incorrectly putting `production` rather than `"production"` into the bundle. This code would break (since `production` would be an undefined variable), and did not measure the sizes correctly.

Example with `react-dom` (before and after the change):

<img width="400" alt="screen shot 2017-07-27 at 7 49 35 pm" src="https://user-images.githubusercontent.com/810438/28686966-ec3aabea-7304-11e7-8d48-bab3c7e10f3c.png">

See also our instructions on the React website:
https://facebook.github.io/react/docs/optimizing-performance.html#webpack

Hope this helps!