### PR TITLE
Add support for total sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,30 @@ import jsize from 'jsize'
 jsize('lodash').then(({ initial, minified, gzipped }) => {
   // Work with values (all in bytes).
 })
+
+// Also supports multiple entries.
+jsize(['lodash/map', 'lodash/filter']).then(({ initial, minified, gzipped }) => {
+  // Work with values (all in bytes).
+})
+```
+
+## Total size of multiple entries.
+
+You can add up multiple entries by using `+` between entry names.
+This is useful because in some cases like in lodash there is a runtime which is a one time cost.
+
+```js
+$ jsize lodash/map+lodash/assign+lodash/filter
+✔ lodash/map + lodash/assign + lodash/filter    6.63 kB (gzipped)
+```
+
+Sizes look much larger when comparing individually because it doesn't account for the shared runtime.
+
+```js
+$ jsize lodash/map lodash/assign lodash/filter
+✔ lodash/map       5.89 kB (gzipped)
+✔ lodash/assign    2.78 kB (gzipped)
+✔ lodash/filter    5.85 kB (gzipped)
 ```
 
 ## Peer Dependencies
@@ -52,12 +76,11 @@ When a package has `peerDependencies` they are automatically excluded from the b
 To have a better idea of the total size of all dependencies you must add up all peers as well.
 
 ```
-$ jsize react react-dom
-✔ react        7.22 kB (gzip)
-✔ react-dom    43.9 kB (gzip)
+$ jsize react
+✔ react    7.23 kB (gzipped)
+$ jsize react+react-dom
+✔ react + react-dom  43.6 kB (gzipped)
 ```
-
-Where the total for `react` in the browser is `51.12kb (gzip)`.
 
 ## License
 

--- a/bin/jsize
+++ b/bin/jsize
@@ -26,10 +26,10 @@ if (program.args.length > 0) {
   // Build and analyze packages sequentially.
   program
     .args
-    .reduce((p, pkg) => p.then(() => {
-      spinner.text = pkg
+    .reduce((p, pkgs) => p.then(() => {
+      spinner.text = colorName(pkgs)
       spinner.start()
-      return jsize(pkg)
+      return jsize(pkgs.split('+'))
         .then(print)
         .catch(err => spinner.fail(err.message))
     }), Promise.resolve())
@@ -46,7 +46,7 @@ if (program.args.length > 0) {
  * @return {number}
  */
 function maxLength (max, it) {
-  return Math.max(max, it.length)
+  return Math.max(max, colorName(it).length)
 }
 
 /**
@@ -81,4 +81,14 @@ function colorBytes (n) {
   } else {
     return chalk.red(str)
   }
+}
+
+/**
+ * Adds colors to package name.
+ *
+ * @param {string} pkgs - the package names to color.
+ * @return {string}
+ */
+function colorName (pkgs) {
+  return pkgs.replace(/\+/g, chalk.dim(' + '))
 }

--- a/index.js
+++ b/index.js
@@ -18,16 +18,31 @@ const resolver = enhancedResolve.ResolverFactory.createResolver({
 /**
  * Calculates the sizes (initial, minified and gziped) for a given package.
  *
- * @param {string} pkg - the package to check the size of.
+ * @param {string|string[]} pkgs - the package(s) to check the size of.
  * @return {Promise}
  */
-module.exports = function jsize (pkg) {
-  const parsed = parsePackageName(pkg)
-  const name = parsed.name
-  const version = parsed.version
-  const file = parsed.path
-  return install(`${name}@${version || 'latest'}`)
-    .then(() => build(name, file))
+module.exports = function jsize (pkgs) {
+  // Parse all package details. (allows for single or multiple packages)
+  pkgs = [].concat(pkgs).map(parsePackageName)
+  // Get unique package ids.
+  const ids = pkgs
+    .map(it => it.name + '@' + (it.version || 'latest'))
+    .filter((id, i, all) => all.indexOf(id) === i)
+
+  // Install modules.
+  return install(ids)
+    // Lookup install paths for each module.
+    .then(() => Promise.all(pkgs.map(loadPaths)))
+    // Extract entry and external files, then build with webpack.
+    .then(paths => build({
+      entry: paths.map(path => path.entry),
+      externals: paths.reduce((externals, path) => {
+        const peers = require(path.package).peerDependencies
+        if (!peers) return externals
+        return externals.concat(Object.keys(peers))
+      }, [])
+    }))
+    // Calculate sizes.
     .then(script => {
       const minimized = uglify.minify(script).code
       return getGzippedSize(minimized).then(gzipped => {
@@ -41,11 +56,11 @@ module.exports = function jsize (pkg) {
 }
 
 /**
- * Installs a package with npm to the temp directory.
+ * Installs packages with npm to the temp directory.
  *
- * @param {string} id - the package to install.
+ * @param {string[]} ids - the list of packages to install.
  */
-function install (id) {
+function install (ids) {
   return new Promise((resolve, reject) => {
     // Temporarily disable logging.
     const log = console.log
@@ -58,7 +73,7 @@ function install (id) {
     }, (err, npm) => {
       if (err) return reject(err)
 
-      npm.commands.install(tmp, [id], (err, deps) => {
+      npm.commands.install(tmp, ids, (err, deps) => {
         // Restore logging.
         console.log = log
         if (err) return reject(err)
@@ -72,40 +87,48 @@ function install (id) {
 /**
  * Uses webpack to build a file in memory and return the bundle.
  *
- * @param {*} name - library folder name
- * @param {*} file - entry point path relative to the library folder
+ * @param {object} config - webpack config options.
  * @return {Promise<string>}
  */
-function build (name, file) {
-  return Promise.all([
-    resolve(tmp, path.join(name, file)),
-    resolve(tmp, path.join(name, 'package.json'))
-  ]).then(results => {
-    const entry = results[0]
-    const peers = require(results[1]).peerDependencies
-    const externals = Object.keys(peers || {})
-
-    return new Promise((resolve, reject) => {
-      const compiler = webpack({
-        target: 'web',
-        output: { filename: 'file' },
-        entry: entry,
-        externals: externals,
-        plugins: [
-          new webpack.optimize.UglifyJsPlugin({ sourcemap: false }),
-          new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"production"', 'process.browser': true })
-        ]
-      }, (err, stats) => {
-        if (err || stats.hasErrors()) reject(err || new Error(stats.toString('errors-only')))
-        const compilation = stats.compilation
-        const compiler = compilation.compiler
-        const memoryFs = compiler.outputFileSystem
-        const outputFile = compilation.assets.file.existsAt
-        resolve(memoryFs.readFileSync(outputFile, 'utf8'))
-      })
-      compiler.outputFileSystem = new MemoryFs()
+function build (config) {
+  return new Promise((resolve, reject) => {
+    const compiler = webpack({
+      target: 'web',
+      entry: config.entry,
+      externals: config.externals,
+      output: { filename: 'file' },
+      plugins: [
+        new webpack.optimize.UglifyJsPlugin({ sourcemap: false }),
+        new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"production"', 'process.browser': true })
+      ]
+    }, (err, stats) => {
+      if (err || stats.hasErrors()) reject(err || new Error(stats.toString('errors-only')))
+      const compilation = stats.compilation
+      const compiler = compilation.compiler
+      const memoryFs = compiler.outputFileSystem
+      const outputFile = compilation.assets.file.existsAt
+      resolve(memoryFs.readFileSync(outputFile, 'utf8'))
     })
+    compiler.outputFileSystem = new MemoryFs()
   })
+}
+
+/**
+ * Given package details loads resolved package and entry files.
+ *
+ * @param {object} pkg - the parsed package details.
+ * @return {Promise}
+ */
+function loadPaths (pkg) {
+  const name = pkg.name
+  const file = pkg.path
+  return Promise.all([
+    resolveFile(tmp, path.join(name, file)),
+    resolveFile(tmp, path.join(name, 'package.json'))
+  ]).then(files => ({
+    entry: files[0],
+    package: files[1]
+  }))
 }
 
 /**
@@ -114,7 +137,7 @@ function build (name, file) {
  * @param {string} file - the file to find.
  * @return {Promise<string>}
  */
-function resolve (dir, file) {
+function resolveFile (dir, file) {
   return new Promise((resolve, reject) => {
     resolver.resolve({}, dir, file, (err, result) => {
       if (err) reject(err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,7 +158,8 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "asn1.js": {
       "version": "4.9.1",


### PR DESCRIPTION
This adds support for https://github.com/antonmedv/jsize/issues/17.

Also this PR is much larger than I initially thought it would be because I realized that I couldn't just add up all of the sizes but instead have to pass all of the entries to webpack.

This is because if we added up all of the sizes it would not account for packages that have a shared runtime. Eg: `lodash/map+lodash/filter` actually has like 5kb shared.

@antonmedv would love your feedback if any.