### PR TITLE
Support spaces around + in arguments

### DIFF
--- a/bin/jsize
+++ b/bin/jsize
@@ -13,6 +13,19 @@ const prettyBytes = require('pretty-bytes')
 const spinner = require('ora')('Starting...').start()
 const jsize = require('../index')
 
+/**
+ * Normalizes cli arguments list.
+ * Replaces `jsize react + react-dom`
+ * With `jsize react+react-dom`
+ */
+process.argv.forEach((arg, i, args) => {
+  if (arg === '+') {
+    const prev = args[i - 1]
+    const next = args[i + 1]
+    args.splice(i - 1, 3, prev + '+' + next)
+  }
+})
+
 // Parse cli options.
 program
   .usage('[options] <name ...>')


### PR DESCRIPTION
This adds greater support for https://github.com/antonmedv/jsize/issues/17 and is the same as https://github.com/antonmedv/jsize/pull/27

I made this PR because it is a bit simpler and doesn't conflict with https://github.com/antonmedv/jsize/pull/26