### PR TITLE
Install packages through cli instead of npm programatic api

### DIFF
--- a/bin/jsize
+++ b/bin/jsize
@@ -11,7 +11,6 @@ const prettyBytes = require('pretty-bytes')
 const stringWidth = require('string-width')
 const createTable = require('text-table')
 const jsize = require('../index')
-const originalLog = console.log
 
 // Check for cli updates.
 updateNotifier({pkg: pkg}).notify()
@@ -146,9 +145,6 @@ function render () {
     table.unshift(headings, [''])
   }
 
-  // Enable logs for long enough to print to the screen.
-  const curLog = console.log
-  console.log = originalLog
   logUpdate(
     '\n' +
     createTable(table, {stringLength: stringWidth})
@@ -157,7 +153,6 @@ function render () {
       .join('\n') +
     '\n'
   )
-  console.log = curLog
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9075,15 +9075,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
-      "integrity": "sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==",
-      "requires": {
-        "commander": "2.11.0",
-        "source-map": "0.5.7"
-      }
-    },
     "uglify-to-browserify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",


### PR DESCRIPTION
@antonmedv this resolves the spacing issue you were having with `@medv/list`.
This also makes it so that we are not relying on the unofficial programatic api for NPM and removes the need for the console.log hacks.